### PR TITLE
Update GEMEtaPartitionMask.h

### DIFF
--- a/RecoLocalMuon/GEMRecHit/src/GEMEtaPartitionMask.h
+++ b/RecoLocalMuon/GEMRecHit/src/GEMEtaPartitionMask.h
@@ -4,7 +4,7 @@
 #include <bitset>
 #include <vector>
 
-const int maskSIZE=96;
+const int maskSIZE=384;
 typedef std::bitset<maskSIZE> EtaPartitionMask;
 
 #endif


### PR DESCRIPTION
EtaPartitionMask size changed to match the number of phi strips in the GEM system
